### PR TITLE
feature: client custom host header

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -409,6 +409,14 @@ SSL handshake if the `wss://` scheme is used.
     [ngx.ssl.parse_pem_priv_key](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/ssl.md#parse_pem_priv_key) 
     function provided by lua-resty-core.
 
+* `host`
+
+    Specifies the value of the `Host` header sent in the handshake request. If not provided, the `Host` header will be derived from the hostname/address and port in the connection URI.
+
+* `server_name`
+
+    Specifies the server name (SNI) to use when performing the TLS handshake with the server. If not provided, the `host` value or the `<host/addr>:<port>` from the connection URI will be used.
+
 The SSL connection mode (`wss://`) requires at least `ngx_lua` 0.9.11 or OpenResty 1.7.4.1.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -84,7 +84,7 @@ function _M.connect(self, uri, opts)
     end
 
     local scheme = m[1]
-    local host = m[2]
+    local addr = m[2]
     local port = m[3]
     local path = m[4]
 
@@ -107,6 +107,7 @@ function _M.connect(self, uri, opts)
     local ssl_verify, server_name, headers, proto_header, origin_header
     local sock_opts = false
     local client_cert, client_priv_key
+    local host
 
     if opts then
         local protos = opts.protocols
@@ -138,9 +139,13 @@ function _M.connect(self, uri, opts)
                    "client_priv_key must be provided with client_cert")
         end
 
-        if opts.ssl_verify or opts.server_name then
+        if opts.ssl_verify then
             ssl_verify = opts.ssl_verify
-            server_name = opts.server_name or host
+        end
+
+        server_name = opts.server_name
+        if server_name ~= nil and type(server_name) ~= "string" then
+            return nil, "SSL server_name must be a string"
         end
 
         if opts.headers then
@@ -149,13 +154,18 @@ function _M.connect(self, uri, opts)
                 return nil, "custom headers must be a table"
             end
         end
+
+        host = opts.host
+        if host ~= nil and type(host) ~= "string" then
+            return nil, "custom host header must be a string"
+        end
     end
 
     local ok, err
     if sock_opts then
-        ok, err = sock:connect(host, port, sock_opts)
+        ok, err = sock:connect(addr, port, sock_opts)
     else
-        ok, err = sock:connect(host, port)
+        ok, err = sock:connect(addr, port)
     end
     if not ok then
         return nil, "failed to connect: " .. err
@@ -168,6 +178,9 @@ function _M.connect(self, uri, opts)
                 return nil, "failed to set TLS client certificate: " .. err
             end
         end
+
+        server_name = server_name or host or addr
+
         ok, err = sock:sslhandshake(false, server_name, ssl_verify)
         if not ok then
             return nil, "ssl handshake failed: " .. err
@@ -201,8 +214,11 @@ function _M.connect(self, uri, opts)
                        rand(256) - 1)
 
     local key = encode_base64(bytes)
+
+    local host_header = host or (addr .. ":" .. port)
+
     local req = "GET " .. path .. " HTTP/1.1\r\nUpgrade: websocket\r\nHost: "
-                .. host .. ":" .. port
+                .. host_header
                 .. "\r\nSec-WebSocket-Key: " .. key
                 .. (proto_header or "")
                 .. "\r\nSec-WebSocket-Version: 13"

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -91,8 +91,13 @@ function _M.connect(self, uri, opts)
     -- ngx.say("host: ", host)
     -- ngx.say("port: ", port)
 
+    local ssl = scheme == "wss"
+    if ssl and not ssl_support then
+        return nil, "ngx_lua 0.9.11+ required for SSL sockets"
+    end
+
     if not port then
-        port = scheme == 'wss' and 443 or 80
+        port = ssl and 443 or 80
     end
 
     if path == "" then
@@ -134,9 +139,6 @@ function _M.connect(self, uri, opts)
         end
 
         if opts.ssl_verify or opts.server_name then
-            if not ssl_support then
-                return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-            end
             ssl_verify = opts.ssl_verify
             server_name = opts.server_name or host
         end
@@ -159,10 +161,7 @@ function _M.connect(self, uri, opts)
         return nil, "failed to connect: " .. err
     end
 
-    if scheme == "wss" then
-        if not ssl_support then
-            return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-        end
+    if ssl then
         if client_cert then
             ok, err = sock:setclientcert(client_cert, client_priv_key)
             if not ok then


### PR DESCRIPTION
Adapted from #1 and rebased onto `Kong:perf/check-ssl-support-early`, which already has its own [PR upstream](https://github.com/openresty/lua-resty-websocket/pull/74) 