### PR TITLE
feature: client custom ws key

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -417,6 +417,10 @@ SSL handshake if the `wss://` scheme is used.
 
     Specifies the server name (SNI) to use when performing the TLS handshake with the server. If not provided, the `host` value or the `<host/addr>:<port>` from the connection URI will be used.
 
+* `key`
+
+    Specifies the value of the `Sec-WebSocket-Key` header in the handshake request. The value should be a base64-encoded, 16 byte string conforming to the client handshake requirements of the [WebSocket RFC](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1). If not provided, a key is randomly generated.
+
 The SSL connection mode (`wss://`) requires at least `ngx_lua` 0.9.11 or OpenResty 1.7.4.1.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -14,6 +14,7 @@ local _send_frame = wbproto.send_frame
 local new_tab = wbproto.new_tab
 local tcp = ngx.socket.tcp
 local re_match = ngx.re.match
+local re_gsub = ngx.re.gsub
 local encode_base64 = ngx.encode_base64
 local concat = table.concat
 local char = string.char


### PR DESCRIPTION
Adapted from #1 and rebased onto `feat/client-custom-host-header` for my own sanity's sake. Best to review and merge after #2 is merged.