### PR TITLE
feature: client connect response

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -374,7 +374,7 @@ Connects to the remote WebSocket service port and performs the websocket handsha
 
 Before actually resolving the host name and connecting to the remote backend, this method will always look up the connection pool for matched idle connections created by previous calls of this method.
 
-The third return value of this method contains the raw, plain-text response (status line and headers) to the handshake request. This allows the caller to perform additional validation and/or extract the response headers. When the connection is reused and no handshake request is sent, the string `connection reused` is returned in lieu of the response.
+The third return value of this method contains the raw, plain-text response (status line and headers) to the handshake request. This allows the caller to perform additional validation and/or extract the response headers. When the connection is reused and no handshake request is sent, the string `"connection reused"` is returned in lieu of the response.
 
 An optional Lua table can be specified as the last argument to this method to specify various connect options:
 

--- a/README.markdown
+++ b/README.markdown
@@ -305,7 +305,7 @@ A simple example to demonstrate the usage:
     local client = require "resty.websocket.client"
     local wb, err = client:new()
     local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
-    local ok, err = wb:connect(uri)
+    local ok, err, res = wb:connect(uri)
     if not ok then
         ngx.say("failed to connect: " .. err)
         return
@@ -362,17 +362,19 @@ An optional options table can be specified. The following options are as follows
 [Back to TOC](#table-of-contents)
 
 #### client:connect
-`syntax: ok, err = wb:connect("ws://<host>:<port>/<path>")`
+`syntax: ok, err, res = wb:connect("ws://<host>:<port>/<path>")`
 
-`syntax: ok, err = wb:connect("wss://<host>:<port>/<path>")`
+`syntax: ok, err, res = wb:connect("wss://<host>:<port>/<path>")`
 
-`syntax: ok, err = wb:connect("ws://<host>:<port>/<path>", options)`
+`syntax: ok, err, res = wb:connect("ws://<host>:<port>/<path>", options)`
 
-`syntax: ok, err = wb:connect("wss://<host>:<port>/<path>", options)`
+`syntax: ok, err, res = wb:connect("wss://<host>:<port>/<path>", options)`
 
 Connects to the remote WebSocket service port and performs the websocket handshake process on the client side.
 
 Before actually resolving the host name and connecting to the remote backend, this method will always look up the connection pool for matched idle connections created by previous calls of this method.
+
+The third return value of this method contains the raw, plain-text response (status line and headers) to the handshake request. This allows the caller to perform additional validation and/or extract the response headers. When the connection is reused and no handshake request is sent, the string `connection reused` is returned in lieu of the response.
 
 An optional Lua table can be specified as the last argument to this method to specify various connect options:
 

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -201,7 +201,7 @@ function _M.connect(self, uri, opts)
     end
     if count > 0 then
         -- being a reused connection (must have done handshake)
-        return 1
+        return 1, nil, "connection reused"
     end
 
     local custom_headers
@@ -256,7 +256,7 @@ function _M.connect(self, uri, opts)
         return nil, "bad HTTP response status line: " .. header
     end
 
-    return 1
+    return 1, nil, header
 end
 
 

--- a/t/cs.t
+++ b/t/cs.t
@@ -2553,9 +2553,6 @@ key: y7KXwBSpVrxtkR0O+bQt+Q==
 
     location = /s {
         content_by_lua_block {
-            ngx.header["x-test"] = "test"
-            ngx.header["x-multi"] = { "one", "two" }
-
             local server = require "resty.websocket.server"
             local wb, err = server:new()
             if not wb then
@@ -2567,7 +2564,7 @@ key: y7KXwBSpVrxtkR0O+bQt+Q==
 --- request
 GET /c
 --- response_body_like
-^HTTP/1\.1 101 Switching Protocols.*
+^HTTP\/1\.1 101 Switching Protocols.*
 --- no_error_log
 [error]
 [warn]
@@ -2617,9 +2614,6 @@ GET /c
 
     location = /s {
         content_by_lua_block {
-            ngx.header["x-test"] = "test"
-            ngx.header["x-multi"] = { "one", "two" }
-
             local server = require "resty.websocket.server"
             local wb, err = server:new()
             if not wb then

--- a/t/cs.t
+++ b/t/cs.t
@@ -2526,3 +2526,114 @@ SSL server name: <test.com>
 GET /c
 --- error_log
 key: y7KXwBSpVrxtkR0O+bQt+Q==
+
+
+
+=== TEST 38: server handshake response string
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            local ok, err, res = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            if not res then
+                ngx.say("no response string")
+                return
+            end
+            ngx.say(res)
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            ngx.header["x-test"] = "test"
+            ngx.header["x-multi"] = { "one", "two" }
+
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+        }
+    }
+--- request
+GET /c
+--- response_body_like
+^HTTP/1\.1 101 Switching Protocols.*
+--- no_error_log
+[error]
+[warn]
+
+
+
+=== TEST 39: server handshake response string (reused connection)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            local ok, err, res = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            if not res then
+                ngx.say("no response string")
+                return
+            end
+
+            if not res:match("^HTTP/1%.1 101 Switching Protocols\r\n") then
+                ngx.say("invalid response string")
+                return
+            end
+
+            ok, err = wb:set_keepalive()
+            if not ok then
+                ngx.say("failed to enable keepalive: ", err)
+                return
+            end
+
+            wb = client:new()
+            ok, err, res = wb:connect(uri)
+            if not ok then
+                ngx.say("second connect failed: ", err)
+                return
+            end
+
+            ngx.say(res)
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            ngx.header["x-test"] = "test"
+            ngx.header["x-multi"] = { "one", "two" }
+
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.sleep(1)
+        }
+    }
+--- request
+GET /c
+--- response_body
+connection reused
+--- no_error_log
+[error]
+[warn]


### PR DESCRIPTION
Adapted from #1 and rebased onto `feat/client-custom-ws-key` from #3.

Prior (unfinished) discussion:

https://github.com/Kong/lua-resty-websocket/pull/1#discussion_r833547796