### PR TITLE
feature: validate handshake response code

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -251,9 +251,13 @@ function _M.connect(self, uri, opts)
 
     -- FIXME: verify the response headers
 
-    m, err = re_match(header, [[^\s*HTTP/1\.1\s+]], "jo")
+    m, err = re_match(header, [[^\s*HTTP/1\.1\s+(\d{3})]], "jo")
     if not m then
         return nil, "bad HTTP response status line: " .. header
+    end
+
+    if m[1] ~= "101" then
+        return nil, "unexpected HTTP response code: " .. m[1], header
     end
 
     return 1, nil, header

--- a/t/cs.t
+++ b/t/cs.t
@@ -2631,3 +2631,37 @@ connection reused
 --- no_error_log
 [error]
 [warn]
+
+
+
+=== TEST 40: server handshake response code must be 101
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            local ok, err, res = wb:connect(uri)
+            if ok then
+                ngx.say("unexpected connection success")
+                return
+            end
+
+            ngx.say("error: \"", err, "\"")
+            ngx.say("response:\n", res)
+        }
+    }
+
+    location = /s {
+        return 400;
+    }
+--- request
+GET /c
+--- response_body_like
+^error: "unexpected HTTP response code: 400"
+response:
+HTTP\/1\.1 400 Bad Request.*
+--- no_error_log
+[error]
+[warn]


### PR DESCRIPTION
Validate that the returned status code is `101` and return an error accordingly. The raw response string is still returned in order to allow callers to inspect it.