### PR TITLE
version bump to 0.2.0

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -37,7 +37,7 @@ then
 end
 
 local _M = new_tab(0, 13)
-_M._VERSION = '0.09'
+_M._VERSION = '0.2.0'
 
 
 local mt = { __index = _M }

--- a/lib/resty/websocket/protocol.lua
+++ b/lib/resty/websocket/protocol.lua
@@ -34,7 +34,7 @@ end
 local _M = new_tab(0, 5)
 
 _M.new_tab = new_tab
-_M._VERSION = '0.09'
+_M._VERSION = '0.2.0'
 
 
 local types = {

--- a/lib/resty/websocket/server.lua
+++ b/lib/resty/websocket/server.lua
@@ -29,7 +29,7 @@ local tostring = tostring
 
 
 local _M = new_tab(0, 10)
-_M._VERSION = '0.09'
+_M._VERSION = '0.2.0'
 
 local mt = { __index = _M }
 

--- a/lua-resty-websocket-kong-0.2.0-1.rockspec
+++ b/lua-resty-websocket-kong-0.2.0-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-websocket-kong"
-version = "0.1.0-2"
+version = "0.2.0-1"
 source = {
   url = "git://github.com/kong/lua-resty-websocket",
-  tag = "0.1.0",
+  tag = "0.2.0",
 }
 description = {
   summary = "Kong-managed fork of lua-resty-websocket",


### PR DESCRIPTION
The version change in the *.lua files isn't intended for upstream (we've diverged from their versioning anyways). It just helps on the Kong side to be able to sanity check `require("resty.websocket.client")._VERSION == <expected>`.