### PR TITLE
feature: discrete send/recv payload limits

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,7 +178,13 @@ An optional options table can be specified. The following options are as follows
 
 * `max_payload_len`
 
-    Specifies the maximal length of payload allowed when sending and receiving WebSocket frames.
+    Specifies the maximal length of payload allowed when sending and receiving WebSocket frames. Defaults to `65536`.
+* `max_recv_len`
+
+    Specifies the maximal length of payload allowed when receiving WebSocket frames. Defaults to the value of `max_payload_len`.
+* `max_send_len`
+
+    Specifies the maximal length of payload allowed when sending WebSocket frames. Defaults to the value of `max_payload_len`.
 * `send_masked`
 
     Specifies whether to send out masked WebSocket frames. When it is `true`, masked frames are always sent. Default to `false`.
@@ -351,7 +357,13 @@ An optional options table can be specified. The following options are as follows
 
 * `max_payload_len`
 
-    Specifies the maximal length of payload allowed when sending and receiving WebSocket frames.
+    Specifies the maximal length of payload allowed when sending and receiving WebSocket frames. Defaults to `65536`.
+* `max_recv_len`
+
+    Specifies the maximal length of payload allowed when receiving WebSocket frames. Defaults to the value of `max_payload_len`.
+* `max_send_len`
+
+    Specifies the maximal length of payload allowed when sending WebSocket frames. Defaults to the value of `max_payload_len`.
 * `send_unmasked`
 
     Specifies whether to send out an unmasked WebSocket frames. When it is `true`, unmasked frames are always sent. Default to `false`. RFC 6455 requires, however, that the client MUST send masked frames to the server, so never set this option to `true` unless you know what you are doing.

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -50,6 +50,7 @@ function _M.new(self, opts)
     end
 
     local max_payload_len, send_unmasked, timeout
+    local max_recv_len, max_send_len
     if opts then
         max_payload_len = opts.max_payload_len
         send_unmasked = opts.send_unmasked
@@ -58,11 +59,16 @@ function _M.new(self, opts)
         if timeout then
             sock:settimeout(timeout)
         end
+
+        max_recv_len = opts.max_recv_len
+        max_send_len = opts.max_send_len
     end
 
     return setmetatable({
         sock = sock,
         max_payload_len = max_payload_len or 65535,
+        max_recv_len = max_recv_len,
+        max_send_len = max_send_len,
         send_unmasked = send_unmasked,
     }, mt)
 end
@@ -284,7 +290,10 @@ function _M.recv_frame(self)
         return nil, nil, "not initialized yet"
     end
 
-    local data, typ, err =  _recv_frame(sock, self.max_payload_len, false)
+    local max_payload_len = self.max_recv_len or
+                            self.max_payload_len
+
+    local data, typ, err =  _recv_frame(sock, max_payload_len, false)
     if not data and not str_find(err, ": timeout", 1, true) then
         self.fatal = true
     end
@@ -306,8 +315,11 @@ local function send_frame(self, fin, opcode, payload)
         return nil, "not initialized yet"
     end
 
+    local max_payload_len = self.max_send_len or
+                            self.max_payload_len
+
     local bytes, err = _send_frame(sock, fin, opcode, payload,
-                                   self.max_payload_len,
+                                   max_payload_len,
                                    not self.send_unmasked)
     if not bytes then
         self.fatal = true

--- a/t/limits.t
+++ b/t/limits.t
@@ -1,0 +1,408 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+use Protocol::WebSocket::Frame;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 7);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "/usr/local/openresty-debug/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
+};
+
+check_accum_error_log();
+no_long_string();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: client max_send_len
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new({
+                max_send_len = 200,
+            })
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            -- ngx.say("uri: ", uri)
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+
+            local frame = string.rep("1", 200)
+
+            local sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.say("failed to send 1st frame: ", err)
+                return
+            end
+
+            ngx.say("1: sent a frame of len ", #frame)
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.say("failed to receive frame: ", err)
+                return
+            end
+
+            ngx.say("2: received ", typ, " frame of len ", #data)
+
+            frame = string.rep("1", 201)
+            sent, err = wb:send_text(frame)
+            if sent then
+                ngx.say("expected sending 2nd frame to fail")
+                return
+            end
+
+            ngx.say("3: failed sending a frame of len ", #frame, ": ", err)
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+            ngx.log(ngx.INFO, "1: received ", typ, " frame of len ", #data)
+
+            local sent, err = wb:send_text(data)
+            if not sent then
+                ngx.log(ngx.ERR, "failed sending frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "2: sent ", typ, " frame of len ", #data)
+        }
+    }
+--- request
+GET /c
+--- response_body
+1: sent a frame of len 200
+2: received text frame of len 200
+3: failed sending a frame of len 201: payload too big
+--- no_error_log
+[error]
+[warn]
+--- error_log
+1: received text frame of len 200
+2: sent text frame of len 200
+
+
+
+=== TEST 2: client max_recv_len
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new({
+                max_recv_len = 200,
+            })
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            -- ngx.say("uri: ", uri)
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+
+            local frame = string.rep("1", 200)
+
+            local sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.say("failed to send 1st frame: ", err)
+                return
+            end
+
+            ngx.say("1: sent a frame of len ", #frame)
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.say("failed to receive frame: ", err)
+                return
+            end
+
+            ngx.say("2: received ", typ, " frame of len ", #data)
+
+            frame = string.rep("1", 201)
+            sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.say("failed to send 2nd frame: ", err)
+                return
+            end
+
+            ngx.say("3: sent a frame of len ", #frame)
+
+            local data, typ, err = wb:recv_frame()
+            if data then
+                ngx.say("expected receiving 2nd frame to fail")
+                return
+
+            elseif err ~= "exceeding max payload len" then
+                ngx.say("unexpected error from recv_frame: ", err)
+                return
+            end
+
+            ngx.say("4: failed receiving frame: ", err)
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "1: received ", typ, " frame of len ", #data)
+
+            local sent, err = wb:send_text(data)
+            if not sent then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "2: sent frame of len ", #data)
+
+            data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "3: received ", typ, " frame of len ", #data)
+
+            sent, err = wb:send_text(data)
+            if not sent then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "4: sent frame of len ", #data)
+        }
+    }
+--- request
+GET /c
+--- response_body
+1: sent a frame of len 200
+2: received text frame of len 200
+3: sent a frame of len 201
+4: failed receiving frame: exceeding max payload len
+--- no_error_log
+[error]
+[warn]
+--- error_log
+1: received text frame of len 200
+2: sent frame of len 200
+3: received text frame of len 201
+4: sent frame of len 201
+
+
+
+=== TEST 3: server max_send_len
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            -- ngx.say("uri: ", uri)
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.say("failed to receive frame: ", err)
+                return
+            end
+
+            ngx.say("1: received ", typ, " frame of len ", #data)
+
+            local frame = string.rep("1", 300)
+            local sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.say("failed sending frame: ", err)
+                return
+            end
+
+            ngx.say("2: sent a text frame of len ", #frame)
+            --wb:recv_frame()
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+            local wb, err = server:new({
+                max_send_len = 200,
+            })
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            local frame = string.rep("1", 200)
+            local sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.log(ngx.ERR, "failed sending 1st frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "1: sent frame of len ", #frame)
+
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "2: received ", typ, " frame of len ", #data)
+
+            sent, err = wb:send_text(data)
+            if sent then
+                ngx.log(ngx.ERR, "expected sending 2nd frame to fail")
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "3: failed sending frame of len ", #data, ": ", err)
+        }
+    }
+--- request
+GET /c
+--- response_body
+1: received text frame of len 200
+2: sent a text frame of len 300
+--- no_error_log
+[error]
+[warn]
+--- error_log
+1: sent frame of len 200
+2: received text frame of len 300
+3: failed sending frame of len 300: payload too big
+
+
+
+=== TEST 4: server max_recv_len
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/s"
+            -- ngx.say("uri: ", uri)
+            local ok, err = wb:connect(uri)
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+
+            local frame = string.rep("1", 200)
+            local sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.say("failed sending frame: ", err)
+                return
+            end
+
+            ngx.say("1: sent text frame of len ", #frame)
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.say("failed to receive frame: ", err)
+                return
+            end
+
+            ngx.say("2: received ", typ, " frame of len ", #data)
+
+            frame = string.rep("1", 300)
+            sent, err = wb:send_text(frame)
+            if not sent then
+                ngx.say("failed sending frame: ", err)
+                return
+            end
+
+            ngx.say("3: sent text frame of len ", #frame)
+        }
+    }
+
+    location = /s {
+        content_by_lua_block {
+            local server = require "resty.websocket.server"
+            local wb, err = server:new({
+                max_recv_len = 200,
+            })
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.log(ngx.ERR, "failed receiving frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "1: received ", typ, " frame of len ", #data)
+
+            local sent, err = wb:send_text(data .. data)
+            if not sent then
+                ngx.log(ngx.ERR, "failed sending frame: ", err)
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "2: sent ", typ, " frame of len ", #data * 2)
+
+            local data, typ, err = wb:recv_frame()
+            if data then
+                ngx.log(ngx.ERR, "expected recv to fail")
+                return ngx.exit(444)
+            end
+
+            ngx.log(ngx.INFO, "3: failed receiving frame: ", err)
+        }
+    }
+--- request
+GET /c
+--- response_body
+1: sent text frame of len 200
+2: received text frame of len 400
+3: sent text frame of len 300
+--- no_error_log
+[error]
+[warn]
+--- error_log
+1: received text frame of len 200
+2: sent text frame of len 400
+3: failed receiving frame: exceeding max payload len


### PR DESCRIPTION
In Kong we have the need to define separate payload limits for client-originated frames and upstream-originated frames. It's ideal to implement these limits within lua-resty-websocket because it stops reading from the socket as soon as it reads a frame header with a size that exceeds the limit, saving lots of effort on `socket:receive()` and (for client frames) un-masking the frame contents.