### PR TITLE
fix(proxy): support legacy http proxy server http/1.0 response for CONNECT

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -264,7 +264,7 @@ function _M.connect(self, uri, opts)
 
             -- FIXME: verify the response headers
 
-            local m, _ = re_match(header, [[^\s*HTTP/1\.1\s+(\d+)]], "jo")
+            local m, _ = re_match(header, [[^\s*HTTP/1\.[01]\s+(\d+)]], "jo")
             if not m then
                 return nil, "bad HTTP response status line: " .. header
             elseif m[1] ~= "200" then

--- a/t/cs.t
+++ b/t/cs.t
@@ -2943,3 +2943,102 @@ bar
 [warn]
 
 
+
+=== TEST 44: SSL with forward proxy and legacy HTTP version
+--- no_check_leak
+--- http_config eval: $::HttpConfig
+--- main_config
+    stream {
+        server {
+            listen 16796;
+
+            error_log logs/error.log debug;
+            content_by_lua_block {
+                require("t.forward-proxy-server").connect({
+                    legacy_http_version = true
+                })
+            }
+        }
+    }
+--- config
+    listen 12345 ssl;
+    server_name test.com;
+    ssl_certificate ../../cert/test.crt;
+    ssl_certificate_key ../../cert/test.key;
+    server_tokens off;
+
+    location = /c {
+        content_by_lua '
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+
+            local uri = "wss://127.0.0.1:12345/s"
+            local ok, err = wb:connect(uri, {
+                proxy_opts = {
+                    wss_proxy = "http://127.0.0.1:16796",
+                },
+            })
+            if not ok then
+                ngx.say("failed to connect: " .. err)
+                return
+            end
+
+            local data = "hello"
+            local bytes, err = wb:send_text(data)
+            if not bytes then
+                ngx.say("failed to send frame: ", err)
+                return
+            end
+
+            local typ
+            data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.say("failed to receive 2nd frame: ", err)
+                return
+            end
+
+            ngx.say("received: ", data, " (", typ, ")")
+
+            -- note our mock forward proxy server does not support
+            -- keepalive, so we must close it here
+            local ok, err = wb:close()
+            if not ok then
+                ngx.say("failed to close conn: ", err)
+                return
+            end
+        ';
+    }
+
+    location = /s {
+        content_by_lua '
+            local server = require "resty.websocket.server"
+            local wb, err = server:new()
+            if not wb then
+                ngx.log(ngx.ERR, "failed to new websocket: ", err)
+                return ngx.exit(444)
+            end
+
+            while true do
+                local data, typ, err = wb:recv_frame()
+                if not data then
+                    -- ngx.log(ngx.ERR, "failed to receive a frame: ", err)
+                    return ngx.exit(444)
+                end
+
+                -- send it back!
+                local bytes, err = wb:send_text(data)
+                if not bytes then
+                    ngx.log(ngx.ERR, "failed to send the 2nd text: ", err)
+                    return ngx.exit(444)
+                end
+            end
+        ';
+    }
+--- request
+GET /c
+--- response_body
+received: hello (text)
+
+--- no_error_log
+[error]
+[warn]


### PR DESCRIPTION
## Summary

There are some cases where the websocket connection may go through a legacy http proxy server which only supports HTTP/1.0. When doing CONNECT request, the http proxy server will respond with HTTP/1.0 200 and that may fail the status line check in the current code. This PR loosen this a bit to support both HTTP/1.1 and HTTP/1.0 response for the CONNECT request.

https://konghq.atlassian.net/browse/FTI-6683