### PR TITLE
feat: add new client api to get server returned status code

### DIFF
--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -340,11 +340,11 @@ function _M.connect(self, uri, opts)
         return nil, "bad HTTP response status line: " .. header
     end
 
-    if m[1] ~= "101" then
+    self.resp_status_code = m[1]
+    self.resp_header = header
+    if self.resp_status_code ~= "101" then
         return nil, "unexpected HTTP response code: " .. m[1], header
     end
-
-    self.resp_header = header
 
     return 1, nil, header
 end
@@ -532,5 +532,8 @@ function _M.get_resp_headers(self)
     return resp_headers
 end
 
+function _M.get_resp_status_code(self)
+    return self.resp_status_code
+end
 
 return _M

--- a/t/count.t
+++ b/t/count.t
@@ -63,7 +63,7 @@ size: 5
 --- request
 GET /t
 --- response_body
-size: 14
+size: 15
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Part of https://konghq.atlassian.net/browse/FTI-6895

We need these new websocket client features to proceed the issue:

1. return the HTTP status code even if the connection fails, so that we can tell if an error is HTTP error or connection level error
2. return the HTTP headers even if the connection fails, so that we can honor the `retry-after` response code when the HTTP status code is 429.
