### PR TITLE
fix(client): keep socket open on non-101 when keep_response=true

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,12 @@ jobs:
         - nginx: "1.21.4"
           openssl: "1.1.1s"
           lua_nginx_module: "master"
-          # v0.0.13 is bundled in OpenResty 1.21.4.2; master drifted out of
-          # compat with nginx 1.21.4 (ngx_stream_ssl_srv_conf_t undefined)
+          # v0.0.13: last tag compat with nginx 1.21.4 (master has
+          # ngx_stream_ssl_srv_conf_t removed, causing compile error)
           stream_lua_nginx_module: "v0.0.13"
-          lua_resty_core: "master"
+          # v0.1.27: last tag that requires stream module >= 13 (v0.0.13);
+          # v0.1.28+ bumped the requirement to 14 which we don't have
+          lua_resty_core: "v0.1.27"
 
     env:
       JOBS: 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,10 @@ jobs:
         include:
         - nginx: "1.21.4"
           openssl: "1.1.1s"
-          lua_nginx_module: "master"
-          # v0.0.13: last tag compat with nginx 1.21.4 (master has
-          # ngx_stream_ssl_srv_conf_t removed, causing compile error)
+          # Pinned to OpenResty 1.21.4.3 bundle; all three modules have drifted
+          # on master and are no longer mutually compatible with nginx 1.21.4.
+          lua_nginx_module: "v0.10.25"
           stream_lua_nginx_module: "v0.0.13"
-          # v0.1.27: last tag that requires stream module >= 13 (v0.0.13);
-          # v0.1.28+ bumped the requirement to 14 which we don't have
           lua_resty_core: "v0.1.27"
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,10 @@ jobs:
         include:
         - nginx: "1.21.4"
           openssl: "1.1.1s"
-          # becasue tagging error on openresty, we use master temporarily
-          # lua_nginx_module: "v0.10.22"
-          # stream_lua_nginx_module: "v0.0.11"
-          # lua_resty_core: "v0.1.24"
           lua_nginx_module: "master"
-          stream_lua_nginx_module: "master"
+          # v0.0.13 is bundled in OpenResty 1.21.4.2; master drifted out of
+          # compat with nginx 1.21.4 (ngx_stream_ssl_srv_conf_t undefined)
+          stream_lua_nginx_module: "v0.0.13"
           lua_resty_core: "master"
 
     env:

--- a/lib/resty/websocket/client.lua
+++ b/lib/resty/websocket/client.lua
@@ -343,12 +343,18 @@ function _M.connect(self, uri, opts)
     self.resp_status_code = m[1]
     self.resp_header = header
     if self.resp_status_code ~= "101" then
-        local closing_ok, closing_err = sock:close()
-        if not closing_ok then
-            ngx_log(ngx_DEBUG, "failed to close the underlying socket: ",
-                closing_err, " when handling a non-101 response")
+        -- RFC 6455 §4.1: a non-101 response means the WebSocket connection
+        -- was never established; mark fatal unconditionally so that no WS
+        -- frames can be sent on what is still a plain HTTP connection.
+        -- When keep_response=true the caller intends to read the HTTP
+        -- response body, so leave the raw socket open for that purpose.
+        if not (opts and opts.keep_response) then
+            local closing_ok, closing_err = sock:close()
+            if not closing_ok then
+                ngx_log(ngx_DEBUG, "failed to close the underlying socket: ",
+                    closing_err, " when handling a non-101 response")
+            end
         end
-
         self.fatal = true
         return nil, "unexpected HTTP response code: " .. m[1], header
     end

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -6,7 +6,7 @@ use Protocol::WebSocket::Frame;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 162 + 6;
+plan tests => repeat_each() * 162 + 18;
 
 my $pwd = cwd();
 
@@ -972,5 +972,89 @@ Sec-WebSocket-Protocol: chat
 GET /c
 --- response_body
 connect result: unexpected HTTP response code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 24: fatal is set and socket is closed after non-101 (default, no keep_response)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/plain"
+            local ok, err = wb:connect(uri)
+            if ok then
+                ngx.say("unexpected ok")
+                return
+            end
+
+            ngx.say("fatal: ", tostring(wb.fatal))
+
+            local _, send_err = wb:send_text("hello")
+            ngx.say("send_text: ", send_err)
+
+            local _, _, recv_err = wb:recv_frame()
+            ngx.say("recv_frame: ", recv_err)
+        }
+    }
+
+    location = /plain {
+        default_type text/plain;
+        return 200 'plain http';
+    }
+--- request
+GET /c
+--- response_body
+fatal: true
+send_text: fatal error already happened
+recv_frame: fatal error already happened
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: keep_response=true leaves socket open for body reading; fatal still set
+--- http_config eval: $::HttpConfig
+--- config
+    location = /c {
+        content_by_lua_block {
+            local client = require "resty.websocket.client"
+            local wb, err = client:new()
+            local uri = "ws://127.0.0.1:" .. ngx.var.server_port .. "/plain"
+            local ok, err = wb:connect(uri, { keep_response = true })
+            if ok then
+                ngx.say("unexpected ok")
+                return
+            end
+
+            ngx.say("fatal: ", tostring(wb.fatal))
+
+            local _, send_err = wb:send_text("hello")
+            ngx.say("send_text: ", send_err)
+
+            -- raw socket is still open; read the HTTP response body directly
+            local body, read_err = wb.sock:receive(10)
+            if read_err then
+                ngx.say("body read failed: ", read_err)
+            else
+                ngx.say("body: ", body)
+            end
+            wb.sock:close()
+        }
+    }
+
+    location = /plain {
+        default_type text/plain;
+        return 200 'plain http';
+    }
+--- request
+GET /c
+--- response_body
+fatal: true
+send_text: fatal error already happened
+body: plain http
 --- no_error_log
 [error]


### PR DESCRIPTION
When a caller sets `keep_response=true` in the connect options, leave the raw TCP socket open after a non-101 response so the caller can still read the HTTP response body (RFC 6455 §4.1: "handle the response per HTTP procedures").

`self.fatal` is now set unconditionally for non-101 responses regardless of `keep_response`, ensuring no WebSocket frames can be sent on a connection that never completed the WebSocket handshake.

Add TEST 24 (default path: fatal set, socket closed, WS ops blocked) and TEST 25 (keep_response=true: fatal set, socket stays open, body readable via raw sock, WS ops still blocked).

KAG-7707
This is a follow-up for https://github.com/Kong/lua-resty-websocket/pull/21